### PR TITLE
Updates PHP dependency to current supported version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,18 +13,18 @@
     ],
     "require": {
         "php": "^7.3",
-        "zendframework/zend-config-aggregator": "^1.0",
-        "zendframework/zend-diactoros": "^1.7.1 || ^2.0",
-        "zendframework/zend-expressive": "^3.0.1",
-        "zendframework/zend-stdlib": "^3.1"
+        "zendframework/zend-config-aggregator": "^1.1.1",
+        "zendframework/zend-diactoros": "^2.1.3",
+        "zendframework/zend-expressive": "^3.2.1",
+        "zendframework/zend-stdlib": "^3.2.1"
     },
     "require-dev": {
-        "filp/whoops": "^2.1.12",
-        "phpunit/phpunit": "^7.0.1",
+        "filp/whoops": "^2.5.0",
+        "phpunit/phpunit": "^7.5.16",
         "roave/security-advisories": "dev-master",
-        "squizlabs/php_codesniffer": "^2.9.1",
-        "zendframework/zend-expressive-tooling": "^1.0",
-        "zfcampus/zf-development-mode": "^3.1"
+        "squizlabs/php_codesniffer": "^2.9.2",
+        "zendframework/zend-expressive-tooling": "^1.2.1",
+        "zfcampus/zf-development-mode": "^3.2.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         "static pages"
     ],
     "require": {
-        "php": "^7.1",
+        "php": "^7.3",
         "zendframework/zend-config-aggregator": "^1.0",
         "zendframework/zend-diactoros": "^1.7.1 || ^2.0",
         "zendframework/zend-expressive": "^3.0.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ae8c117f1fef3c9c8d695a1636b3ee9b",
+    "content-hash": "d782e83ed17591efb12ef649701db3d6",
     "packages": [
         {
             "name": "fig/http-message-util",
@@ -1023,34 +1023,35 @@
         },
         {
             "name": "ocramius/package-versions",
-            "version": "1.4.0",
+            "version": "1.5.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Ocramius/PackageVersions.git",
-                "reference": "a4d4b60d0e60da2487bd21a2c6ac089f85570dbb"
+                "reference": "1d32342b8c1eb27353c8887c366147b4c2da673c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Ocramius/PackageVersions/zipball/a4d4b60d0e60da2487bd21a2c6ac089f85570dbb",
-                "reference": "a4d4b60d0e60da2487bd21a2c6ac089f85570dbb",
+                "url": "https://api.github.com/repos/Ocramius/PackageVersions/zipball/1d32342b8c1eb27353c8887c366147b4c2da673c",
+                "reference": "1d32342b8c1eb27353c8887c366147b4c2da673c",
                 "shasum": ""
             },
             "require": {
                 "composer-plugin-api": "^1.0.0",
-                "php": "^7.1.0"
+                "php": "^7.3.0"
             },
             "require-dev": {
-                "composer/composer": "^1.6.3",
-                "doctrine/coding-standard": "^5.0.1",
+                "composer/composer": "^1.8.6",
+                "doctrine/coding-standard": "^6.0.0",
                 "ext-zip": "*",
-                "infection/infection": "^0.7.1",
-                "phpunit/phpunit": "^7.0.0"
+                "infection/infection": "^0.13.4",
+                "phpunit/phpunit": "^8.2.5",
+                "vimeo/psalm": "^3.4.9"
             },
             "type": "composer-plugin",
             "extra": {
                 "class": "PackageVersions\\Installer",
                 "branch-alias": {
-                    "dev-master": "2.0.x-dev"
+                    "dev-master": "1.6.x-dev"
                 }
             },
             "autoload": {
@@ -1069,7 +1070,7 @@
                 }
             ],
             "description": "Composer plugin that provides efficient querying for installed package versions (no runtime IO)",
-            "time": "2019-02-21T12:16:21+00:00"
+            "time": "2019-07-17T15:49:50+00:00"
         },
         {
             "name": "phar-io/manifest",
@@ -1977,8 +1978,8 @@
             "authors": [
                 {
                     "name": "Marco Pivetta",
-                    "role": "maintainer",
-                    "email": "ocramius@gmail.com"
+                    "email": "ocramius@gmail.com",
+                    "role": "maintainer"
                 }
             ],
             "description": "Prevents installation of composer packages with known security vulnerabilities: no API, simply require it",
@@ -3364,7 +3365,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "^7.1"
+        "php": "^7.3"
     },
     "platform-dev": []
 }


### PR DESCRIPTION
* PHP 7.1 is a dead version on 1 Dec 2019
* the active support for PHP 7.2 ends on 30 Nov 2019

https://www.php.net/supported-versions.php