### PR TITLE
Add core documentation for a Zend Framework project

### DIFF
--- a/docs/CODE_OF_CONDUCT.md
+++ b/docs/CODE_OF_CONDUCT.md
@@ -1,6 +1,6 @@
 # Contributor Code of Conduct
 
-The Zend Framework project adheres to [The Code Manifesto](http://codemanifesto.com)
+This project adheres to [The Code Manifesto](http://codemanifesto.com)
 as its guidelines for contributor interactions.
 
 ## The Code Manifesto
@@ -41,3 +41,4 @@ In the effort to create such a place, we hold to these values:
 8. **To err is human.** You might not intend it, but mistakes do happen and
    contribute to build experience. Tolerate honest mistakes, and don't hesitate
    to apologize if you make one yourself.
+

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -2,67 +2,37 @@
 
 ## RESOURCES
 
-If you wish to contribute to Zend Framework, please be sure to
+If you wish to contribute to this project, please be sure to
 read/subscribe to the following resources:
 
- -  [Coding Standards](https://github.com/zendframework/zf2/wiki/Coding-Standards)
- -  [Contributor's Guide](http://framework.zend.com/participate/contributor-guide)
- -  ZF Contributor's mailing list:
-    Archives: http://zend-framework-community.634137.n4.nabble.com/ZF-Contributor-f680267.html
-    Subscribe: zf-contributors-subscribe@lists.zend.com
- -  ZF Contributor's IRC channel:
-    #zftalk.dev on Freenode.net
+ - [Coding Standards](https://github.com/zendframework/zend-coding-standard)
+ - [Forums](https://discourse.zendframework.com/c/contributors)
+ - [Slack](https://zendframework-slack.herokuapp.com)
+ - [Code of Conduct](CODE_OF_CONDUCT.md)
 
-If you are working on new features or refactoring [create a proposal](https://github.com/zendframework/zend-servicemanager/issues/new).
-
-## Reporting Potential Security Issues
-
-If you have encountered a potential security vulnerability, please **DO NOT** report it on the public
-issue tracker: send it to us at [zf-security@zend.com](mailto:zf-security@zend.com) instead.
-We will work with you to verify the vulnerability and patch it as soon as possible.
-
-When reporting issues, please provide the following information:
-
-- Component(s) affected
-- A description indicating how to reproduce the issue
-- A summary of the security vulnerability and impact
-
-We request that you contact us via the email address above and give the project
-contributors a chance to resolve the vulnerability and issue a new release prior
-to any public exposure; this helps protect users and provides them with a chance
-to upgrade and/or update in order to protect their applications.
-
-For sensitive email communications, please use [our PGP key](http://framework.zend.com/zf-security-pgp-key.asc).
+If you are working on new features or refactoring
+[create a proposal](https://github.com/zendframework/zend-expressive-static-pages/issues/new).
 
 ## RUNNING TESTS
-
-> ### Note: testing versions prior to 2.4
->
-> This component originates with Zend Framework 2. During the lifetime of ZF2,
-> testing infrastructure migrated from PHPUnit 3 to PHPUnit 4. In most cases, no
-> changes were necessary. However, due to the migration, tests may not run on
-> versions < 2.4. As such, you may need to change the PHPUnit dependency if
-> attempting a fix on such a version.
 
 To run tests:
 
 - Clone the repository:
 
   ```console
-  $ git clone git@github.com:zendframework/zend-servicemanager.git
-  $ cd
+  $ git clone git://github.com/zendframework/zend-expressive-static-pages.git
+  $ cd zend-expressive-static-pages
   ```
 
 - Install dependencies via composer:
 
   ```console
-  $ curl -sS https://getcomposer.org/installer | php --
-  $ ./composer.phar install
+  $ composer install
   ```
 
-  If you don't have `curl` installed, you can also download `composer.phar` from https://getcomposer.org/
+  If you don't have `composer` installed, please download it from https://getcomposer.org/download/
 
-- Run the tests:
+- Run the tests using the "test" command shipped in the `composer.json`:
 
   ```console
   $ composer test
@@ -77,23 +47,22 @@ To do so:
 
 ## Running Coding Standards Checks
 
-This component follows [PSR-1](http://www.php-fig.org/psr/psr-1/) and
-[PSR-2](http://www.php-fig.org/psr/psr-2/) guidelines, and ships with tooling
-for both checking code against standards, as well as fixing most errors.
+First, ensure you've installed dependencies via composer, per the previous
+section on running tests.
 
-To run checks only:
+To run CS checks only:
 
 ```console
 $ composer cs-check
 ```
 
-To fix common errors:
+To attempt to automatically fix common CS issues:
 
 ```console
 $ composer cs-fix
 ```
 
-If you allow tooling to fix CS issues, please re-run the tests to ensure
+If the above fixes any CS issues, please re-run the tests to ensure
 they pass, and make sure you add and commit the changes after verification.
 
 ## Recommended Workflow for Contributions
@@ -102,20 +71,20 @@ Your first step is to establish a public repository from which we can
 pull your work into the master repository. We recommend using
 [GitHub](https://github.com), as that is where the component is already hosted.
 
-1. Setup a [GitHub account](http://github.com/), if you haven't yet
-2. Fork the repository (http://github.com/zendframework/zend-servicemanager)
+1. Setup a [GitHub account](https://github.com/), if you haven't yet
+2. Fork the repository (https://github.com/zendframework/zend-expressive-static-pages)
 3. Clone the canonical repository locally and enter it.
 
    ```console
-   $ git clone git://github.com:zendframework/zend-servicemanager.git
-   $ cd zend-servicemanager
+   $ git clone git://github.com/zendframework/zend-expressive-static-pages.git
+   $ cd zend-expressive-static-pages
    ```
 
 4. Add a remote to your fork; substitute your GitHub username in the command
    below.
 
    ```console
-   $ git remote add {username} git@github.com:{username}/zend-servicemanager.git
+   $ git remote add {username} git@github.com:{username}/zend-expressive-static-pages.git
    $ git fetch {username}
    ```
 
@@ -178,7 +147,7 @@ Delta compression using up to 2 threads.
 Compression objects: 100% (18/18), done.
 Writing objects: 100% (20/20), 8.19KiB, done.
 Total 20 (delta 12), reused 0 (delta 0)
-To ssh://git@github.com/{username}/zend-servicemanager.git
+To ssh://git@github.com/{username}/zend-expressive-static-pages.git
    b5583aa..4f51698  HEAD -> master
 ```
 
@@ -187,15 +156,7 @@ To send a pull request, you have two options.
 If using GitHub, you can do the pull request from there. Navigate to
 your repository, select the branch you just created, and then select the
 "Pull Request" button in the upper right. Select the user/organization
-"zendframework" as the recipient.
-
-If using your own repository - or even if using GitHub - you can use `git
-format-patch` to create a patchset for us to apply; in fact, this is
-**recommended** for security-related patches. If you use `format-patch`, please
-send the patches as attachments to:
-
--  zf-devteam@zend.com for patches without security implications
--  zf-security@zend.com for security patches
+"zendframework" (or whatever the upstream organization is) as the recipient.
 
 #### What branch to issue the pull request against?
 
@@ -227,7 +188,3 @@ repository, we suggest doing some cleanup of these branches.
    $ git push {username} :<branchname>
    ```
 
-
-## Conduct
-
-Please see our [CONDUCT.md](CONDUCT.md) to understand expected behavior when interacting with others in the project.

--- a/docs/ISSUE_TEMPLATE.md
+++ b/docs/ISSUE_TEMPLATE.md
@@ -1,0 +1,20 @@
+ - [ ] I was not able to find an [open](https://github.com/zendframework/zend-expressive-static-pages/issues?q=is%3Aopen) or [closed](https://github.com/zendframework/zend-expressive-static-pages/issues?q=is%3Aclosed) issue matching what I'm seeing.
+ - [ ] This is not a question. (Questions should be asked on [slack](https://zendframework.slack.com/) ([Signup for Slack here](https://zendframework-slack.herokuapp.com/)) or our [forums](https://discourse.zendframework.com/).)
+
+Provide a narrative description of what you are trying to accomplish.
+
+### Code to reproduce the issue
+
+<!-- Please provide the minimum code necessary to recreate the issue -->
+
+```php
+```
+
+### Expected results
+
+<!-- What do you think should have happened? -->
+
+### Actual results
+
+<!-- What did you actually observe? -->
+

--- a/docs/SUPPORT.md
+++ b/docs/SUPPORT.md
@@ -1,0 +1,27 @@
+# Getting Support
+
+Zend Framework offers three support channels:
+
+- For real-time questions, use our
+  [Slack](https://zendframework-slack.herokuapp.com)
+- For detailed questions (e.g., those requiring examples) use our
+  [forums](https://discourse.zendframework.com/c/questions/expressive)
+- To report issues, use this repository's
+  [issue tracker](https://github.com/zendframework/zend-expressive-static-pages/issues/new)
+
+**DO NOT** use the issue tracker to ask questions; use Slack or the forums for
+that.
+Questions posed to the issue tracker will be closed.
+
+When reporting an issue, please include the following details:
+
+- A narrative description of what you are trying to accomplish.
+- The minimum code necessary to reproduce the issue.
+- The expected results of exercising that code.
+- The actual results received.
+
+We may ask for additional details: what version of the library you are using,
+and what PHP version was used to reproduce the issue.
+
+You may also submit a failing test case as a pull request.
+


### PR DESCRIPTION
This change adds the code of conduct, contributing guide, support guide, issue and PR templates common to Zend Framework projects.